### PR TITLE
Add Practical API and LaTeX course pages, registration button, and update courses index

### DIFF
--- a/app/courses/latex-scientific-writing/page.tsx
+++ b/app/courses/latex-scientific-writing/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import {
+  ArrowRight,
+  BookOpen,
+  CheckCircle2,
+  Clock3,
+  Code2,
+  GraduationCap,
+  Layers3,
+  Target,
+  Users,
+} from "lucide-react";
+import { Header } from "@/components/header";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CourseRegistrationButton } from "@/components/course-registration-button";
+
+// پس از آماده‌شدن صفحه انجمن علمی، لینک ثبت‌نام در این متغیر قرار می‌گیرد.
+const registrationUrl = "";
+
+const sessions = [
+  {
+    number: "۱",
+    title: "مبانی LaTeX و نگارش علمی و ریاضی",
+    description: "شروع از یک پروژه خالی و آشنایی با منطق LaTeX، ساختار سند، نگارش ریاضی و فارسی‌نویسی.",
+    sections: [
+      { title: "آشنایی با LaTeX", items: ["تفاوت LaTeX با نرم‌افزارهای واژه‌پرداز", "کاربردهای دانشگاهی و فرایند Source، Compile و PDF", "ساخت اولین سند و شناخت خطاهای متداول Compile"] },
+      { title: "ساختار سند", items: ["documentclass، Preamble و Document", "Command، Environment، آرگومان و Option", "Commentها، Packageها و شیوه استفاده از آن‌ها"] },
+      { title: "ساختاربندی علمی", items: ["عنوان، نویسنده و تاریخ", "Section، Subsection و Paragraph", "فهرست‌های شماره‌دار و بدون شماره و کاراکترهای خاص"] },
+      { title: "نگارش روابط ریاضی", items: ["Inline Math و Display Math؛ توان، اندیس، کسر و رادیکال", "حروف یونانی، توابع، بردارها، مشتق، انتگرال، مجموع و حد", "ماتریس‌ها، روابط چندخطی و شماره‌گذاری روابط", "کار با amsmath، amssymb، amsfonts و آشنایی مقدماتی با amsthm"] },
+      { title: "فارسی‌نویسی", items: ["آشنایی با XeLaTeX و xepersian", "تنظیم فونت فارسی و ترکیب متن فارسی و انگلیسی", "استفاده از روابط ریاضی در اسناد فارسی"] },
+    ],
+  },
+  {
+    number: "۲",
+    title: "جداول، داده‌ها، نمودارها و تصاویر",
+    description: "نمایش استاندارد و خوانای اطلاعات و داده‌های علمی در سند.",
+    sections: [
+      { title: "اعداد، کمیت‌ها و یکاها", items: ["کار با siunitx برای نمایش استاندارد اعداد، کمیت‌ها و یکاها", "عدم‌قطعیت و قالب‌بندی داده‌های عددی", "استفاده از اعداد و یکاها در متن، روابط و جداول"] },
+      { title: "ساخت جداول", items: ["محیط‌های tabular و table، تعریف سطر و ستون و Alignment", "Caption، Label و شماره‌گذاری", "جداول علمی خوانا با booktabs و ستون‌های عددی siunitx"] },
+      { title: "رسم داده‌های علمی", items: ["workflow اصلی pgfplots و تعریف محورهای نمودار", "عنوان، برچسب محورها و وارد کردن داده‌ها", "رسم نقاط، نمودارهای خطی و داده‌های گسسته و تنظیم ظاهر"] },
+      { title: "تصاویر و شکل‌ها", items: ["درج و تنظیم ابعاد تصاویر با graphicx", "محیط figure، Caption، Label و شماره‌گذاری خودکار", "افزودن خروجی نمودارهای نرم‌افزارهای دیگر به سند"] },
+    ],
+  },
+  {
+    number: "۳",
+    title: "ارجاع‌دهی، مدیریت منابع و سند نهایی",
+    description: "اتصال اجزای سند، مدیریت منابع علمی و آماده‌سازی خروجی نهایی.",
+    sections: [
+      { title: "ارجاع داخلی", items: ["label، ref و eqref", "ارجاع خودکار به روابط، شکل‌ها، جداول و Sectionها", "نام‌گذاری درست Labelها و مزیت ارجاع خودکار"] },
+      { title: "منابع علمی و فایل .bib", items: ["Citation، Bibliography و ساخت و مدیریت فایل .bib", "ساختار BibTeX Entry، Citation Key و انواع article، book، inproceedings و misc", "فیلدهای author، title، journal، year، volume، number، pages، publisher، doi و url", "biblatex، biber و Citation/Bibliography Style", "دریافت اطلاعات BibTeX منابع و آشنایی با ابزارهای مدیریت منابع"] },
+      { title: "صفحه‌آرایی", items: ["اندازه صفحه و حاشیه‌ها با geometry", "Header، Footer، شماره صفحه و اطلاعات سربرگ و پابرگ با fancyhdr"] },
+      { title: "جمع‌بندی", items: ["تکمیل ساختار یک سند علمی کامل", "سازمان‌دهی فایل‌ها و عیب‌یابی خطاهای Compile", "استفاده از مستندات Packageها و مسیر ادامه یادگیری"] },
+    ],
+  },
+];
+
+const packages = [
+  ["amsmath", "مدیریت روابط ریاضی"], ["amssymb", "نمادهای ریاضی"], ["amsfonts", "فونت‌ها و مجموعه‌های ریاضی"],
+  ["amsthm", "محیط‌های theorem"], ["xepersian", "فارسی‌نویسی"], ["siunitx", "اعداد، کمیت‌ها و یکاها"],
+  ["booktabs", "جداول علمی"], ["graphicx", "مدیریت تصاویر"], ["pgfplots", "رسم و نمایش داده‌ها"],
+  ["biblatex / biber", "ارجاع و مدیریت منابع"], ["geometry", "ابعاد و حاشیه‌ها"], ["fancyhdr", "سربرگ و پابرگ"],
+];
+
+const outcomes = ["متن فارسی و انگلیسی", "بخش‌ها و زیربخش‌ها", "روابط و نمادهای ریاضی", "جدول و نمودار داده‌ها", "تصاویر و شماره‌گذاری خودکار", "ارجاع داخلی", "Citation و فهرست منابع .bib", "صفحه‌آرایی استاندارد"];
+
+export default function LatexCoursePage() {
+  return (
+    <div className="min-h-screen bg-background" dir="rtl">
+      <Header />
+      <main>
+        <section className="border-b border-border bg-linear-to-b from-violet-500/10 via-background to-background">
+          <div className="mx-auto max-w-6xl px-4 py-14 sm:px-6 sm:py-20 lg:px-8">
+            <Link href="/courses" className="mb-8 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground">
+              <ArrowRight className="size-4" /> بازگشت به دوره‌ها
+            </Link>
+            <div className="max-w-4xl">
+              <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-violet-500/20 bg-violet-500/10 px-3 py-1 text-xs font-bold text-violet-600 dark:text-violet-400">
+                <GraduationCap className="size-4" /> دوره مقدماتی و پروژه‌محور
+              </div>
+              <h1 className="text-3xl font-black leading-tight tracking-tight sm:text-5xl">آموزش کاربردی <span dir="ltr" className="text-violet-600 dark:text-violet-400">LaTeX</span> برای نگارش علمی و دانشگاهی</h1>
+              <p className="mt-6 max-w-3xl text-base leading-8 text-muted-foreground sm:text-lg">در این دوره، بدون نیاز به آشنایی قبلی با LaTeX، مهم‌ترین ابزارهای موردنیاز برای تهیه یک سند علمی استاندارد را در قالب یک پروژه واقعی یاد می‌گیرید؛ نه صرفاً مجموعه‌ای از دستورها.</p>
+              <div className="mt-8 grid max-w-3xl grid-cols-1 gap-3 sm:grid-cols-3">
+                {[[Clock3, "مدت دوره", "۳ جلسه ۷۰ دقیقه‌ای"], [Layers3, "سطح", "مقدماتی"], [Users, "پیش‌نیاز", "ندارد"]].map(([Icon, label, value]) => {
+                  const ItemIcon = Icon as typeof Clock3;
+                  return <div key={label as string} className="flex items-center gap-3 rounded-xl border border-border bg-card/70 p-4"><ItemIcon className="size-5 text-violet-500" /><div><div className="text-xs text-muted-foreground">{label as string}</div><div className="mt-1 text-sm font-bold">{value as string}</div></div></div>;
+                })}
+              </div>
+              <CourseRegistrationButton href={registrationUrl} className="mt-6" />
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto flex max-w-6xl flex-col gap-16 px-4 py-14 sm:px-6 lg:px-8">
+          <section className="grid gap-6 lg:grid-cols-2">
+            <div className="rounded-2xl border border-border bg-card p-6 sm:p-8"><Target className="mb-4 size-7 text-violet-500" /><h2 className="text-xl font-extrabold">هدف دوره</h2><p className="mt-3 text-sm leading-7 text-muted-foreground">پس از سه جلسه می‌توانید به‌صورت مستقل یک سند علمی یا فنی استاندارد بسازید و ساختار، محتوای چندزبانه، داده‌ها، ارجاعات و ظاهر آن را مدیریت کنید.</p></div>
+            <div className="rounded-2xl border border-border bg-card p-6 sm:p-8"><Users className="mb-4 size-7 text-violet-500" /><h2 className="text-xl font-extrabold">این دوره برای چه کسانی است؟</h2><p className="mt-3 text-sm leading-7 text-muted-foreground">دانشجویان تمام رشته‌ها، به‌ویژه علوم پایه و مهندسی که با گزارش علمی و فنی، روابط ریاضی، داده‌ها، مقاله، پروژه یا پایان‌نامه سروکار دارند.</p></div>
+          </section>
+
+          <section><div className="mb-8"><span className="text-sm font-bold text-violet-500">برنامه آموزشی</span><h2 className="mt-2 text-2xl font-black sm:text-3xl">سرفصل جلسات</h2></div><div className="space-y-8">{sessions.map((session) => <article key={session.number} className="overflow-hidden rounded-2xl border border-border bg-card"><div className="flex flex-col gap-4 border-b border-border bg-muted/40 p-6 sm:flex-row sm:items-center"><span className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-violet-500 text-xl font-black text-white">{session.number}</span><div><h3 className="text-xl font-extrabold">جلسه {session.number} — {session.title}</h3><p className="mt-1 text-sm text-muted-foreground">{session.description}</p></div></div><div className="grid gap-8 p-6 md:grid-cols-2">{session.sections.map((section) => <div key={section.title}><h4 className="mb-3 flex items-center gap-2 font-bold"><BookOpen className="size-4 text-violet-500" />{section.title}</h4><ul className="space-y-2">{section.items.map((item) => <li key={item} className="flex gap-2 text-sm leading-6 text-muted-foreground"><CheckCircle2 className="mt-1 size-4 shrink-0 text-violet-500" /><span>{item}</span></li>)}</ul></div>)}</div></article>)}</div></section>
+
+          <section><div className="mb-7"><span className="text-sm font-bold text-violet-500">جعبه‌ابزار دوره</span><h2 className="mt-2 text-2xl font-black">Packageها و ابزارهای اصلی</h2></div><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{packages.map(([name, use]) => <div key={name} className="flex items-center gap-3 rounded-xl border border-border bg-card p-4"><Code2 className="size-5 shrink-0 text-violet-500" /><div><code dir="ltr" className="font-bold text-foreground">{name}</code><p className="mt-0.5 text-xs text-muted-foreground">{use}</p></div></div>)}</div></section>
+
+          <section className="rounded-3xl border border-violet-500/20 bg-violet-500/5 p-6 sm:p-10"><div className="grid gap-10 lg:grid-cols-[1fr_1.3fr]"><div><span className="text-sm font-bold text-violet-500">خروجی مورد انتظار</span><h2 className="mt-2 text-2xl font-black">در پایان چه می‌سازید؟</h2><p className="mt-4 text-sm leading-7 text-muted-foreground">از یک پروژه خالی شروع می‌کنید و به یک سند علمی یا فنی کامل، منظم و قابل توسعه می‌رسید.</p></div><div className="grid gap-3 sm:grid-cols-2">{outcomes.map((outcome, index) => <div key={outcome} className="flex items-center gap-3 rounded-xl bg-background p-3 text-sm font-medium shadow-sm"><span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-violet-500/10 text-xs font-bold text-violet-500">{index + 1}</span>{outcome}</div>)}</div></div></section>
+
+          <section className="text-center"><h2 className="text-2xl font-black">یادگیری عملی، قابل استفاده و مستقل</h2><p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-muted-foreground">مثال‌ها محدود به یک رشته خاص نیستند و برای دانشجویان رشته‌های مختلف علوم و مهندسی طراحی شده‌اند. هدف نهایی، توانایی استفاده مستقل از LaTeX برای نیازهای واقعی دانشگاهی است.</p><div className="mt-6 flex flex-wrap justify-center gap-3"><CourseRegistrationButton href={registrationUrl} /><Link href="/courses" className={cn(buttonVariants({ variant: "outline", size: "lg" }))}><ArrowRight className="size-4" /> مشاهده همه دوره‌ها</Link></div></section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -2,12 +2,52 @@
 
 import * as React from "react";
 import { Header } from "@/components/header";
-import { GraduationCap, BookOpen, Download, Users, CheckCircle, Code, Award } from "lucide-react";
+import { GraduationCap, BookOpen, Download, Users, CheckCircle, Code, Award, Sigma, ArrowLeft, Braces } from "lucide-react";
 import Link from "next/link";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const courses = [
+  {
+    id: "practical-api",
+    title: "آموزش API؛ از Postman و Python تا FastAPI",
+    category: "Web Development",
+    duration: "۳ جلسه عملی",
+    studentsCount: "مقدماتی",
+    icon: Braces,
+    color: "text-cyan-500",
+    bgColor: "bg-cyan-500/10",
+    borderColor: "border-cyan-500/20",
+    description: "یادگیری عملی هر دو سمت API با سناریوی یک فروشگاه آنلاین؛ از آزمایش Requestها تا ساخت API با FastAPI.",
+    syllabus: [
+      "API، HTTP، JSON و کار با Postman",
+      "فراخوانی API و پردازش Response در Python",
+      "Authentication، مدیریت خطا و Pagination",
+      "ساخت Endpoint و اعتبارسنجی با FastAPI و Pydantic",
+      "مستندات خودکار با OpenAPI و Swagger",
+    ],
+    href: "/courses/practical-api",
+  },
+  {
+    id: "latex-scientific-writing",
+    title: "آموزش کاربردی LaTeX برای نگارش علمی و دانشگاهی",
+    category: "Scientific Writing",
+    duration: "۳ جلسه، مجموعاً ۲۱۰ دقیقه",
+    studentsCount: "سطح مقدماتی",
+    icon: Sigma,
+    color: "text-violet-500",
+    bgColor: "bg-violet-500/10",
+    borderColor: "border-violet-500/20",
+    description: "یک دوره عملی و پروژه‌محور برای ساخت مستقل اسناد علمی فارسی و انگلیسی، از روابط ریاضی و نمودار تا ارجاع‌دهی و مدیریت منابع.",
+    syllabus: [
+      "مبانی LaTeX، ساختار سند و فارسی‌نویسی",
+      "نگارش روابط و نمادهای ریاضی",
+      "جداول، داده‌ها، نمودارها و تصاویر",
+      "ارجاع داخلی و مدیریت منابع با BibLaTeX",
+      "صفحه‌آرایی و تکمیل یک سند علمی استاندارد",
+    ],
+    href: "/courses/latex-scientific-writing",
+  },
   {
     id: "physics-10",
     title: "High School 10th Grade Physics",
@@ -87,7 +127,7 @@ export default function CoursesPage() {
         </div>
 
         {/* Courses Overview Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
           {courses.map((course) => {
             const Icon = course.icon;
             return (
@@ -136,10 +176,17 @@ export default function CoursesPage() {
                 </div>
 
                 <div className="mt-6 pt-4 border-t border-border/50 flex items-center justify-between">
-                  <Button variant="outline" size="sm" className="w-full text-xs font-mono flex items-center gap-2">
-                    <Download className="size-3.5" />
-                    Download Syllabus & Slides (PDF)
-                  </Button>
+                  {course.href ? (
+                    <Link href={course.href} className={cn(buttonVariants({ variant: "outline", size: "sm" }), "w-full text-xs flex items-center gap-2")}>
+                      مشاهده جزئیات و سرفصل کامل
+                      <ArrowLeft className="size-3.5" />
+                    </Link>
+                  ) : (
+                    <Button variant="outline" size="sm" className="w-full text-xs font-mono flex items-center gap-2">
+                      <Download className="size-3.5" />
+                      Download Syllabus & Slides (PDF)
+                    </Button>
+                  )}
                 </div>
               </div>
             );
@@ -165,9 +212,9 @@ export default function CoursesPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row items-center justify-between gap-4 text-xs text-muted-foreground font-mono">
           <div>© {new Date().getFullYear()} Abulfadl Ahmadi. Educational Archive.</div>
           <div className="flex items-center gap-4">
-            <a href="/" className="hover:text-foreground">Home</a>
+            <Link href="/" className="hover:text-foreground">Home</Link>
             <span>•</span>
-            <a href="/notes" className="hover:text-foreground">Physics Notes</a>
+            <Link href="/notes" className="hover:text-foreground">Physics Notes</Link>
           </div>
         </div>
       </footer>

--- a/app/courses/practical-api/page.tsx
+++ b/app/courses/practical-api/page.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { ArrowRight, BookOpen, CheckCircle2, Clock3, Code2, GraduationCap, Laptop, Route, ShoppingCart, Target, Users } from "lucide-react";
+import { Header } from "@/components/header";
+import { CourseRegistrationButton } from "@/components/course-registration-button";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// پس از آماده‌شدن صفحه انجمن علمی، لینک ثبت‌نام در این متغیر قرار می‌گیرد.
+const registrationUrl = "";
+
+const sessions = [
+  {
+    number: "۱",
+    title: "API، HTTP و کار عملی با Postman",
+    goal: "شناخت ساختار API و ارسال Requestهای مختلف با استفاده از مستندات و Collection یک فروشگاه آنلاین.",
+    sections: [
+      { title: "مبانی API", items: ["Client، Server، API Consumer و API Provider", "Resource، Endpoint، URL و Base URL", "جایگاه API در معماری نرم‌افزار"] },
+      { title: "HTTP و Request", items: ["HTTP و HTTPS و چرخه Request/Response", "متدهای GET، POST، PUT، PATCH و DELETE", "Headers، Query و Path Parameters، Body و Content-Type"] },
+      { title: "Response و JSON", items: ["Status Code، Response Headers، Body و Response Time", "Object، Array، انواع داده و ساختارهای تو در تو در JSON", "تحلیل کدهای 2xx، 4xx و 5xx و پیدا کردن خطا"] },
+      { title: "کار عملی با Postman", items: ["ساخت Request و ارسال Params، Headers و JSON Body", "Collections، Import، Variables و Environments", "بررسی Endpointهای Products، Categories، Cart و Orders"] },
+      { title: "Authentication", items: ["تفاوت Authentication و Authorization", "API Key، Token و Bearer Token", "Login، دریافت Token و ارسال Authorization Header"] },
+    ],
+  },
+  {
+    number: "۲",
+    title: "کار با API در Python",
+    goal: "تبدیل Requestهای آزمایش‌شده در Postman به یک برنامه Python واقعی و قابل اتکا.",
+    sections: [
+      { title: "Requests و دریافت داده", items: ["نصب و استفاده از کتابخانه requests", "GET Request، Status Code و تبدیل Response به JSON", "Query Parameters، Path Parameters و ساخت URL"] },
+      { title: "تغییر داده", items: ["POST، PATCH و DELETE", "ارسال JSON و Request Body", "پردازش Dictionary، List، Nested Data و Array of Objects"] },
+      { title: "امنیت و احراز هویت", items: ["Login، دریافت و نگهداری Token", "API Key، Bearer Token و Authorization Header", "Environment Variables، فایل .env، Secretها و .gitignore"] },
+      { title: "یک Client مقاوم", items: ["مدیریت Status ناموفق، Connection Error، Timeout و Invalid Response", "Exception Handling و رفتار مناسب هنگام خطا", "Pagination با Page، Limit، Offset و Cursor و مدیریت Rate Limit 429"] },
+      { title: "سناریوی عملی", items: ["دریافت و جست‌وجوی محصولات", "ورود و ارسال Request احرازشده", "افزودن محصول به سبد خرید و ایجاد سفارش"] },
+    ],
+  },
+  {
+    number: "۳",
+    title: "ساخت API با FastAPI",
+    goal: "تجربه نقش API Provider با ساخت بخشی از Backend فروشگاه و اتصال دوباره آن به Postman و Python.",
+    sections: [
+      { title: "شروع FastAPI", items: ["Web Framework و معرفی FastAPI", "ایجاد پروژه، نصب وابستگی‌ها و Development Server", "ساخت اولین Endpoint و شناخت Routeها"] },
+      { title: "Products API", items: ["ساخت GET، POST، PATCH و DELETE برای محصولات", "Path و Query Parameters", "دریافت Request Body و بازگرداندن JSON"] },
+      { title: "Validation و Response", items: ["Modelها، Type Hints و فیلدهای Required و Optional در Pydantic", "اعتبارسنجی ورودی و مشاهده Validation Error", "Status Codeهای 200، 201، 204 و 404 و Error Handling"] },
+      { title: "OpenAPI و Swagger", items: ["API Schema و مستندات خودکار FastAPI", "مشاهده Parameters، Request Body و Response Schema", "آزمایش Endpointها از داخل Swagger UI"] },
+      { title: "پروژه پایانی", items: ["اجرای Products API ساخته‌شده", "اتصال Postman به برنامه FastAPI", "اتصال اختیاری Python Client و مشاهده چرخه کامل Client/Server"] },
+    ],
+  },
+];
+
+const tools = ["HTTP / HTTPS", "REST API", "JSON", "Postman", "Python", "Requests", "Environment Variables", ".env", "FastAPI", "Pydantic", "OpenAPI", "Swagger UI"];
+const outcomes = ["خواندن مستندات یک API جدید", "انتخاب Endpoint و HTTP Method مناسب", "ساخت Request با Parameters، Headers و Body", "آزمایش API با Postman", "فراخوانی API در Python", "پردازش JSON و مدیریت خطا", "پیاده‌سازی Authentication", "ساخت یک API ساده با FastAPI"];
+
+const endpointExample = `GET     /products
+GET     /products/{id}
+POST    /products
+PATCH   /products/{id}
+DELETE  /products/{id}
+
+POST    /auth/login
+GET     /users/me
+POST    /cart/items
+POST    /orders`;
+
+export default function PracticalApiCoursePage() {
+  return (
+    <div className="min-h-screen bg-background" dir="rtl">
+      <Header />
+      <main>
+        <section className="border-b border-border bg-linear-to-b from-cyan-500/10 via-background to-background">
+          <div className="mx-auto max-w-6xl px-4 py-14 sm:px-6 sm:py-20 lg:px-8">
+            <Link href="/courses" className="mb-8 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"><ArrowRight className="size-4" /> بازگشت به دوره‌ها</Link>
+            <div className="max-w-4xl">
+              <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs font-bold text-cyan-700 dark:text-cyan-400"><GraduationCap className="size-4" /> عملی و پروژه‌محور</div>
+              <h1 className="text-3xl font-black leading-tight tracking-tight sm:text-5xl">دوره آموزشی <span dir="ltr" className="text-cyan-600 dark:text-cyan-400">API</span></h1>
+              <h2 className="mt-3 text-xl font-bold sm:text-2xl">از Postman و Python تا FastAPI</h2>
+              <p className="mt-6 max-w-3xl text-base leading-8 text-muted-foreground sm:text-lg">یادگیری عملی API با سناریوی یک فروشگاه آنلاین؛ ابتدا API را در Postman می‌آزماییم، سپس با Python فراخوانی می‌کنیم و در پایان بخشی از آن را با FastAPI می‌سازیم.</p>
+              <div className="mt-8 grid max-w-3xl gap-3 sm:grid-cols-3">{[[Clock3, "مدت", "۳ جلسه عملی"], [Users, "پیش‌نیاز", "Python مقدماتی"], [Laptop, "همراه داشته باشید", "لپ‌تاپ شخصی"]].map(([Icon, label, value]) => { const ItemIcon = Icon as typeof Clock3; return <div key={label as string} className="flex items-center gap-3 rounded-xl border border-border bg-card/70 p-4"><ItemIcon className="size-5 text-cyan-500" /><div><div className="text-xs text-muted-foreground">{label as string}</div><div className="mt-1 text-sm font-bold">{value as string}</div></div></div>; })}</div>
+              <CourseRegistrationButton href={registrationUrl} className="mt-6 bg-cyan-600 text-white hover:bg-cyan-700" />
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto flex max-w-6xl flex-col gap-16 px-4 py-14 sm:px-6 lg:px-8">
+          <section className="grid gap-6 lg:grid-cols-2"><div className="rounded-2xl border border-border bg-card p-6 sm:p-8"><Target className="mb-4 size-7 text-cyan-500" /><h2 className="text-xl font-extrabold">هدف دوره</h2><p className="mt-3 text-sm leading-7 text-muted-foreground">هدف حفظ تعریف‌ها نیست؛ یاد می‌گیرید مستندات را بخوانید، Request درست بسازید، Response و خطا را تحلیل کنید، احراز هویت انجام دهید و هر دو سمت Client و Server را بفهمید.</p></div><div className="rounded-2xl border border-border bg-card p-6 sm:p-8"><Users className="mb-4 size-7 text-cyan-500" /><h2 className="text-xl font-extrabold">مناسب چه کسانی است؟</h2><p className="mt-3 text-sm leading-7 text-muted-foreground">برای برنامه‌نویسان مقدماتی، علاقه‌مندان Web و Backend و کسانی که می‌خواهند API سرویس‌های پرداخت، پیامک، نقشه، شبکه‌های اجتماعی، سرویس‌های ابری یا هوش مصنوعی را در پروژه‌هایشان به کار بگیرند.</p></div></section>
+
+          <section className="grid items-center gap-8 rounded-3xl border border-cyan-500/20 bg-cyan-500/5 p-6 lg:grid-cols-2 lg:p-10"><div><div className="mb-4 flex items-center gap-2 text-sm font-bold text-cyan-600"><ShoppingCart className="size-5" /> سناریوی مشترک سه جلسه</div><h2 className="text-2xl font-black">API یک فروشگاه آنلاین</h2><p className="mt-4 text-sm leading-7 text-muted-foreground">با Resourceهای Products، Categories، Users، Authentication، Cart و Orders کار می‌کنیم تا هر مفهوم را روی یک سیستم منسجم ببینیم.</p></div><pre dir="ltr" className="overflow-x-auto rounded-2xl bg-zinc-950 p-5 text-left font-mono text-xs leading-6 text-cyan-300"><code>{endpointExample}</code></pre></section>
+
+          <section><div className="mb-8"><span className="text-sm font-bold text-cyan-600">Use → Understand → Implement → Build</span><h2 className="mt-2 text-2xl font-black sm:text-3xl">مسیر و سرفصل سه جلسه</h2></div><div className="space-y-8">{sessions.map((session) => <article key={session.number} className="overflow-hidden rounded-2xl border border-border bg-card"><div className="flex flex-col gap-4 border-b border-border bg-muted/40 p-6 sm:flex-row sm:items-center"><span className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-cyan-600 text-xl font-black text-white">{session.number}</span><div><h3 className="text-xl font-extrabold">جلسه {session.number} — {session.title}</h3><p className="mt-1 text-sm text-muted-foreground">{session.goal}</p></div></div><div className="grid gap-8 p-6 md:grid-cols-2">{session.sections.map((section) => <div key={section.title}><h4 className="mb-3 flex items-center gap-2 font-bold"><BookOpen className="size-4 text-cyan-500" />{section.title}</h4><ul className="space-y-2">{section.items.map((item) => <li key={item} className="flex gap-2 text-sm leading-6 text-muted-foreground"><CheckCircle2 className="mt-1 size-4 shrink-0 text-cyan-500" />{item}</li>)}</ul></div>)}</div></article>)}</div></section>
+
+          <section><div className="mb-7"><span className="text-sm font-bold text-cyan-600">ابزارها و فناوری‌ها</span><h2 className="mt-2 text-2xl font-black">جعبه‌ابزار دوره</h2></div><div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">{tools.map((tool) => <div key={tool} dir="ltr" className="flex items-center gap-3 rounded-xl border border-border bg-card p-4 text-left"><Code2 className="size-5 text-cyan-500" /><code className="font-bold">{tool}</code></div>)}</div></section>
+
+          <section className="grid gap-8 lg:grid-cols-2"><div className="rounded-2xl border border-border p-6 sm:p-8"><Route className="mb-4 size-7 text-cyan-500" /><h2 className="text-xl font-extrabold">پیش‌نیاز و آماده‌سازی</h2><p className="mt-3 text-sm leading-7 text-muted-foreground">آشنایی مقدماتی با متغیرها، انواع داده، شرط، حلقه، تابع، List، Dictionary و Import در Python توصیه می‌شود. تجربه قبلی API یا Backend لازم نیست. پیش از دوره Python، Postman و یک Code Editor یا IDE را نصب کنید.</p></div><div className="rounded-2xl border border-border p-6 sm:p-8"><GraduationCap className="mb-4 size-7 text-cyan-500" /><h2 className="text-xl font-extrabold">دستاورد نهایی</h2><div className="mt-4 grid gap-2 sm:grid-cols-2">{outcomes.map((outcome) => <div key={outcome} className="flex gap-2 text-sm text-muted-foreground"><CheckCircle2 className="mt-0.5 size-4 shrink-0 text-cyan-500" />{outcome}</div>)}</div></div></section>
+
+          <section className="rounded-3xl bg-cyan-600 p-8 text-center text-white sm:p-12"><h2 className="text-2xl font-black">آماده‌اید چرخه کامل API را تجربه کنید؟</h2><p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-cyan-50">از خواندن مستندات و ارسال Request تا پردازش Response و ساخت Endpoint در سمت Server.</p><div className="mt-6 flex flex-wrap justify-center gap-3"><CourseRegistrationButton href={registrationUrl} className="bg-white text-cyan-700 hover:bg-cyan-50" /><Link href="/courses" className={cn(buttonVariants({ variant: "outline", size: "lg" }), "border-white/40 bg-transparent text-white hover:bg-white/10 hover:text-white")}><ArrowRight className="size-4" /> همه دوره‌ها</Link></div></section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/components/course-registration-button.tsx
+++ b/components/course-registration-button.tsx
@@ -1,0 +1,22 @@
+import { ExternalLink } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type CourseRegistrationButtonProps = {
+  href: string;
+  className?: string;
+};
+
+export function CourseRegistrationButton({ href, className }: CourseRegistrationButtonProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(buttonVariants({ size: "lg" }), "gap-2", className)}
+    >
+      ثبت‌نام در دوره
+      <ExternalLink className="size-4" />
+    </a>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide dedicated course detail pages for two new offerings (Practical API and LaTeX for scientific writing) so users can view full syllabi and register. 
- Introduce a reusable registration control to keep CTA styling consistent across course pages. 
- Surface the new courses on the main courses index and improve navigation to course detail pages. 
- Replace raw anchor tags with `Link` where appropriate to use the Next.js router consistently.

### Description
- Added two new course pages at `app/courses/practical-api/page.tsx` and `app/courses/latex-scientific-writing/page.tsx` with full RTL content, session breakdowns, tools/outcomes lists, and stylized layouts. 
- Introduced a reusable `CourseRegistrationButton` component at `components/course-registration-button.tsx` which renders an external registration link with consistent button styles. 
- Updated the courses index at `app/courses/page.tsx` to register the two new courses in the `courses` array, import additional icons, adjust the grid layout (`md`/`xl` columns), and render a conditional detail `Link` when a course `href` is present. 
- Minor adjustments include replacing `<a>` with `Link` in the footer, updated button/link variants, and placeholder `registrationUrl` fields in new pages for later wiring.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c883586188328a3c2eaf40f1ba7ef)